### PR TITLE
Put rebar3_hex in project_plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.


### PR DESCRIPTION
This commit moves rebar3_hex into project plugins so that it doesn't get downloaded by users of sleeplocks.


Hi @whitfin :) I hope this finds you well. 